### PR TITLE
Bump react-router from 4.3.1 to 6.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mobx": "^5.15.7",
     "react": "^15.7.0",
     "react-dom": "^15.7.0",
-    "react-router": "^4.3.1",
+    "react-router": "^6.2.1",
     "redux": "^4.1.2"
   }
 }


### PR DESCRIPTION
- Bumps [react-router](https://github.com/remix-run/react-router) from 4.3.1 to 6.2.1