### PR TITLE
Bump mobx from 6.3.0 to 6.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "jquery": "^2.2.4",
     "lodash": "^4.17.21",
-    "mobx": "^6.3.0",
+    "mobx": "^6.4.2",
     "react": "^15.7.0",
     "react-dom": "^15.7.0",
     "react-router": "^4.3.1",


### PR DESCRIPTION
"- Bumps [react](https://github.com/facebook/react) from 15.7.0 to 17.0.2\n\n<details>\n<summary>Release notes</summary>\n<p><em>Sourced from <a href=\"https://github.com/servicetitan/anvil/releases\"><code>@​servicetitan/tokens</code>'s releases</a>.</em></p>\n\n\n## Features\n\n- `[jest-config]` Support comments in JSON config file ([#12316](https://github.com/facebook/jest/pull/12316))\n- `[pretty-format]` Expose `ConvertAnsi` plugin ([#12308](https://github.com/facebook/jest/pull/12308))\n\n## Fixes\n\n- `[expect]` Add type definitions for asymmetric `closeTo` matcher ([#12304](https://github.com/facebook/jest/pull/12304))\n- `[jest-cli]` Load binary via exported API ([#12315](https://github.com/facebook/jest/pull/12315))\n- `[jest-config]` Replace `jsonlint` with `parse-json` ([#12316](https://github.com/facebook/jest/pull/12316))\n- `[jest-repl]` Make module importable ([#12311](https://github.com/facebook/jest/pull/12311) & [#12315](https://github.com/facebook/jest/pull/12315))\n\n## Chore & Maintenance\n\n- `[*]` Avoid anonymous default exports ([#12313](https://github.com/facebook/jest/pull/12313))\n\n## New Contributors\n* @zoltan-boros made their first contribution in https://github.com/facebook/jest/pull/12206\n\n**Full Changelog**: https://github.com/facebook/jest/compare/v27.5.0...v27.5.1\n\n</details>"