### PR TITLE
Bump @auto-it packages from 10.31.0 to 10.34.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   },
   "homepage": "https://github.com/rgdelato/hello-world-using-action#readme",
   "dependencies": {
-    "@auto-it/first-time-contributor": "^10.31.0",
-    "@auto-it/omit-release-notes": "^10.31.0",
-    "@auto-it/released": "^10.31.0",
+    "@auto-it/first-time-contributor": "^10.34.1",
+    "@auto-it/omit-release-notes": "^10.34.1",
+    "@auto-it/released": "^10.34.1",
     "@types/jest": "^27.0.1",
     "auto": "^10.31.0",
     "jest": "^27.2.0",


### PR DESCRIPTION
- Bumps [@auto-it/first-time-contributor](https://github.com/intuit/auto) from 10.31.0 to 10.34.1
- Bumps [@auto-it/omit-release-notes](https://github.com/intuit/auto) from 10.31.0 to 10.34.1
- Bumps [@auto-it/released](https://github.com/intuit/auto) from 10.31.0 to 10.34.1


<details>
<summary>Latest release notes</summary>
<p><em>Sourced from <a href="https://github.com/intuit/auto/releases/tag/v10.34.1"><code>intuit/auto</code>'s releases</a>.</em></p>
<blockquote>

# v10.34.1
#### 🐛 Bug Fix

- `@auto-it/gradle`
 - [Gradle] Fix canary version reporting [#2160](https://github.com/intuit/auto/pull/2160) ([@sugarmanz](https://github.com/sugarmanz))

#### Authors: 1

- Jeremiah Zucker ([@sugarmanz](https://github.com/sugarmanz))

</blockquote>
 </details>

<em><code>intuit/auto</code>'s top-level, root <a href="https://github.com/intuit/auto/blob/v10.34.1/CHANGELOG.md">CHANGELOG.md</a></em>